### PR TITLE
added QEMU_EXTRA_ARGS environment variable

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -165,6 +165,16 @@ docker run -it --rm -e "BOOT=http://www.example.com/image.iso" --device=/dev/kvm
 
     Please note that even if you don't need DHCP, it's still recommended to enable this feature as it prevents NAT issues and increases performance by using a `macvtap` interface.
 
+  * ### How do I provide other arguments to QEMU?
+
+    You can create the `QEMU_EXTRA_ARGS` environment variable to provide additional arguments to QEMU at runtime:
+
+    ```yaml
+    environment:
+        QEMU_EXTRA_ARGS: "-drive file=/seed.iso,format=raw,if=virtio"
+    ```
+
+
 [build_url]: https://github.com/qemu-tools/qemu-docker/
 [ghcr_url]: https://github.com/orgs/qemu-tools/packages/container/package/qemu-docker
 

--- a/run/run.sh
+++ b/run/run.sh
@@ -66,8 +66,12 @@ MAC_OPTS="-machine type=q35,usb=off,dump-guest-core=off,hpet=off${KVM_OPTS}"
 SERIAL_OPTS="-serial mon:stdio -device virtio-serial-pci,id=virtio-serial0,bus=pcie.0,addr=0x3"
 EXTRA_OPTS="-device virtio-balloon-pci,id=balloon0 -object rng-random,id=rng0,filename=/dev/urandom -device virtio-rng-pci,rng=rng0"
 
-ARGS="${DEF_OPTS} ${CPU_OPTS} ${RAM_OPTS} ${MAC_OPTS} ${MON_OPTS} ${SERIAL_OPTS} ${NET_OPTS} ${DISK_OPTS} ${EXTRA_OPTS}"
+env | grep -iq QEMU_EXTRA_ARGS || QEMU_EXTRA_ARGS=""
+
+ARGS="${DEF_OPTS} ${CPU_OPTS} ${RAM_OPTS} ${MAC_OPTS} ${MON_OPTS} ${SERIAL_OPTS} ${NET_OPTS} ${DISK_OPTS} ${EXTRA_OPTS} ${QEMU_EXTRA_ARGS}"
 ARGS=$(echo "$ARGS" | sed 's/\t/ /g' | tr -s ' ')
+
+echo "Running with arguments: ${ARGS}"
 
 trap - ERR
 


### PR DESCRIPTION
This will allow users to append extra arguments to the `qemu-system-x86_64` binary.

I attempted to implement cloud-init support, but for some reason, I could not get the Ubuntu VM to boot the drive I had created. https://github.com/qemu-tools/qemu-docker/issues/145

Regardless, I think this is a small, but useful Quality of Life addition.